### PR TITLE
Added missing environments

### DIFF
--- a/sample_apps/9-arcgis-api-service/src/environments/environment.prod.ts
+++ b/sample_apps/9-arcgis-api-service/src/environments/environment.prod.ts
@@ -1,0 +1,3 @@
+export const environment = {
+  production: true
+};

--- a/sample_apps/9-arcgis-api-service/src/environments/environment.ts
+++ b/sample_apps/9-arcgis-api-service/src/environments/environment.ts
@@ -1,0 +1,8 @@
+// The file contents for the current environment will overwrite these during build.
+// The build system defaults to the dev environment which uses `environment.ts`, but if you do
+// `ng build --env=prod` then `environment.prod.ts` will be used instead.
+// The list of which env maps to which file can be found in `.angular-cli.json`.
+
+export const environment = {
+  production: false
+};


### PR DESCRIPTION
Example 9 doesn't build because of missing environment config (it was throwing `ERROR in TypeError: Cannot read property 'length' of undefined`)